### PR TITLE
Updated sure test version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.17</version>
+					<version>2.18.1</version>
 				</plugin>
 				<plugin>
 					<groupId>com.google.code.maven-replacer-plugin</groupId>


### PR DESCRIPTION

Error on executing mave test case with surefire pulgin. Current maven projectsurefire pulgin  has 2.17 artifacte ID but jenkins considering default version(2.18.1) 

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.18.1:test (default-test) on project spring-boot-sample-war: There are test failures.
[ERROR] 
[ERROR] Please refer to /var/lib/jenkins/workspace/Project1/spring-boot-samples/spring-boot-sample-war/target/surefire-reports for the individual test results.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] 